### PR TITLE
Fixed tool deconstruction issue

### DIFF
--- a/src/main/java/slimeknights/tconstruct/tools/common/client/GuiToolStation.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/client/GuiToolStation.java
@@ -221,7 +221,7 @@ public class GuiToolStation extends GuiTinkerStation {
     }
 
     // current tool to deconstruct
-    if (Config.deconstructTools && container.deconstruct) {
+    if (Config.deconstructTools && container.getTile().isDeconstructing()) {
       warning(Util.translate("gui.warning.deconstruct_tool"));
     }
     // current tool to build or repair/modify

--- a/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerToolStation.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerToolStation.java
@@ -49,8 +49,7 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
   protected ToolCore selectedTool; // needed for newly opened containers to sync
   protected int activeSlots;
   public String toolName;
-  public boolean deconstruct;
-
+  
   public ContainerToolStation(InventoryPlayer playerInventory, TileToolStation tile) {
     super(tile);
     this.player = playerInventory.player;
@@ -65,7 +64,11 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
     out = new SlotToolStationOut(i, 124, 38, this);
     addSlotToContainer(out);
     this.addPlayerInventory(playerInventory, 8, 84 + 8);
-    onCraftMatrixChanged(playerInventory);
+    if (tile.isDeconstructing()) {
+      out.inventory.setInventorySlotContents(0, tile.getDeconstructingStack());
+    } else {
+      onCraftMatrixChanged(playerInventory);
+    }
   }
 
   public List<ItemStack> getInputSlotContents() {
@@ -143,7 +146,7 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
   }
 
   public void setToolName(String name) {
-    this.toolName = name;
+	this.toolName = name;
 
     if(world.isRemote) {
       GuiScreen screen = Minecraft.getMinecraft().currentScreen;
@@ -166,10 +169,10 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
   // update crafting - called whenever the content of an input slot changes
   @Override
   public void onCraftMatrixChanged(IInventory inventoryIn) {
-    // reset gui state
+	// reset gui state
     updateGUI();
     try {
-      ItemStack result;
+      ItemStack result = ItemStack.EMPTY;
       // 1. try repairing
       result = repairTool(false);
       // 2. try swapping tool parts
@@ -197,7 +200,6 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
       // if no crafting result and a tool is in the output slot, try deconstruction
       else if(Config.deconstructTools && !outputStack.isEmpty() && outputStack.getItem() instanceof TinkersItem) {
         if(deconstructTool()) {
-          deconstruct = true;
           // populate input slots with parts
           NonNullList<ItemStack> parts = getDeconstructedParts(outputStack);
           for(int i = 0; i < activeSlots && i < parts.size(); i++) {
@@ -211,10 +213,11 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
           // keep tool in output slot
           out.inventory.setInventorySlotContents(0, outputStack);
         }
+    	tile.setDeconstructingStack(out.inventory.getStackInSlot(0));
       } else {
         // no crafting result and no valid tool for deconstruction
-        deconstruct = false;
         out.inventory.setInventorySlotContents(0, ItemStack.EMPTY);
+  	    tile.setDeconstructingStack(out.inventory.getStackInSlot(0));
       }
       updateGUI();
     } catch(TinkerGuiException e) {
@@ -222,6 +225,7 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
       out.inventory.setInventorySlotContents(0, ItemStack.EMPTY);
       this.error(e.getMessage());
     }
+    
     // sync output with other open containers on the server
     if(!this.world.isRemote) {
       WorldServer server = (WorldServer) this.world;
@@ -238,13 +242,13 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
     boolean resultTaken = false;
 
     try {
-      if(Config.deconstructTools && deconstruct) {
+      if(Config.deconstructTools && this.tile.isDeconstructing()) {
         // clear input slots to remove previewed parts
         for(int i = 0; i < activeSlots; i++) {
           tile.setInventorySlotContents(i, ItemStack.EMPTY);
         }
         onCraftMatrixChanged(null);
-        deconstruct = false;
+  	    tile.setDeconstructingStack(out.inventory.getStackInSlot(0));
         return;
       } else {
         resultTaken = !repairTool(true).isEmpty() ||
@@ -471,7 +475,7 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
       }
     }
   }
-
+  
   private NonNullList<ItemStack> getInputs() {
     NonNullList<ItemStack> input = NonNullList.withSize(tile.getSizeInventory() - 1, ItemStack.EMPTY);
     for(int i = 1; i < tile.getSizeInventory(); i++) {

--- a/src/main/java/slimeknights/tconstruct/tools/common/tileentity/TileToolStation.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/tileentity/TileToolStation.java
@@ -1,5 +1,7 @@
 package slimeknights.tconstruct.tools.common.tileentity;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockPane;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -7,6 +9,7 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.property.IExtendedBlockState;
@@ -25,6 +28,8 @@ import slimeknights.tconstruct.tools.common.inventory.ContainerToolStation;
 
 public class TileToolStation extends TileTable implements IInventoryGui {
 
+  protected ItemStack deconstructingStack = ItemStack.EMPTY;
+	
   public TileToolStation() {
     super("gui.toolstation.name", 6);
     this.itemHandler = new ConfigurableInvWrapperCapability(this, false, false);
@@ -51,31 +56,66 @@ public class TileToolStation extends TileTable implements IInventoryGui {
     if(Minecraft.getMinecraft().currentScreen instanceof GuiToolStation) {
       info = ((GuiToolStation) Minecraft.getMinecraft().currentScreen).currentInfo;
     }*/
-    float s = 0.46875f;
-
-    for(int i = 0; i < info.positions.size(); i++) {
-      ItemStack stackInSlot = getStackInSlot(i);
-      PropertyTableItem.TableItem item = getTableItem(stackInSlot, this.getWorld(), null);
-      if(item != null) {
-        item.x = (33 - info.positions.get(i).getX()) / 61f;
-        item.z = (42 - info.positions.get(i).getY()) / 61f;
-        item.s *= s;
-
-        if(i == 0 || info != GuiButtonRepair.info) {
-          item.s *= 1.3f;
-        }
-
-        // correct itemblock because scaling
-        if(stackInSlot.getItem() instanceof ItemBlock && !(Block.getBlockFromItem(stackInSlot.getItem())  instanceof BlockPane)) {
-          item.y = -(1f - item.s) / 2f;
-        }
-
-        //item.s *= 2/5f;
-        toDisplay.items.add(item);
-      }
+    
+    if (!this.deconstructingStack.isEmpty()) {
+	  PropertyTableItem.TableItem item = getTableItem(this.deconstructingStack, this.getWorld(), null);
+	  toDisplay.items.add(item);
+    } else {
+    
+	  float s = 0.46875f;
+	    
+	  for(int i = 0; i < info.positions.size(); i++) {
+	    ItemStack stackInSlot = getStackInSlot(i);
+	    PropertyTableItem.TableItem item = getTableItem(stackInSlot, this.getWorld(), null);
+        if(item != null) {
+	      item.x = (33 - info.positions.get(i).getX()) / 61f;
+	      item.z = (42 - info.positions.get(i).getY()) / 61f;
+	      item.s *= s;
+	
+	      if(i == 0 || info != GuiButtonRepair.info) {
+	        item.s *= 1.3f;
+	      }
+	
+	      // correct itemblock because scaling
+	      if(stackInSlot.getItem() instanceof ItemBlock && !(Block.getBlockFromItem(stackInSlot.getItem())  instanceof BlockPane)) {
+	        item.y = -(1f - item.s) / 2f;
+	      }
+	
+	        //item.s *= 2/5f;
+	      toDisplay.items.add(item);
+	    }
+	  }
     }
+    
 
     // add inventory if needed
     return state.withProperty(BlockTable.INVENTORY, toDisplay);
+  }
+  
+  public void setDeconstructingStack(ItemStack stack) {
+	this.deconstructingStack = stack;
+  }
+
+  public ItemStack getDeconstructingStack() {
+	return this.deconstructingStack;
+  }
+  
+  public boolean isDeconstructing() {
+	return !deconstructingStack.isEmpty();
+  }
+  
+  @Override
+  public void readFromNBT(NBTTagCompound tags) {
+	super.readFromNBT(tags);
+	ItemStack stack = new ItemStack(tags.getCompoundTag("DeconstructingStack"));
+	this.setDeconstructingStack(stack);
+  }
+  
+  @Nonnull
+  @Override
+  public NBTTagCompound writeToNBT(NBTTagCompound tags) {
+	NBTTagCompound tag = super.writeToNBT(tags);
+	tag.setTag("DeconstructingStack", deconstructingStack.serializeNBT());
+	return tag;
   }
 }


### PR DESCRIPTION
Essentially, I make he following changes

 - I tied the deconstruction state to the tileentity rather than the container, which fixed a bunch of issues with leaving a tool in the GUI, exiting, and then reopening.
 - I added an additional in-world station rendering segment to better show that the tool is being deconstructed which shows the tool as a whole while it is being deconstructed
  