### PR TITLE
De-randomize JEI recipe order

### DIFF
--- a/src/main/java/slimeknights/tconstruct/plugin/jei/alloy/AlloyRecipeChecker.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/alloy/AlloyRecipeChecker.java
@@ -2,13 +2,13 @@ package slimeknights.tconstruct.plugin.jei.alloy;
 
 import java.util.Set;
 
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.smeltery.AlloyRecipe;
 
 public class AlloyRecipeChecker {
   public static Set<AlloyRecipe> getAlloyRecipes() {
-    Set<AlloyRecipe> recipes = new ObjectOpenHashSet<>();
+    Set<AlloyRecipe> recipes = new ObjectLinkedOpenHashSet<>();
 
     for(AlloyRecipe recipe : TinkerRegistry.getAlloys()) {
       if(recipe.getFluids() != null && !recipe.getFluids().isEmpty() && recipe.getResult() != null && recipe.getResult().amount > 0) {

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/casting/CastingRecipeChecker.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/casting/CastingRecipeChecker.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import org.apache.commons.lang3.tuple.Triple;
 
 import com.google.common.collect.Lists;
@@ -27,7 +27,7 @@ public class CastingRecipeChecker {
   private static CastingRecipeWrapper recipeWrapper;
 
   public static Set<CastingRecipeWrapper> getCastingRecipes() {
-    Set<CastingRecipeWrapper> recipes = new ObjectOpenHashSet<>();
+    Set<CastingRecipeWrapper> recipes = new ObjectLinkedOpenHashSet<>();
     Map<Triple<Item, Item, Fluid>, List<ItemStack>> castDict = new Object2ObjectOpenHashMap<>();
 
     // skip recipes with brass or alubrass if those are not integrated

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/drying/DryingRecipeChecker.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/drying/DryingRecipeChecker.java
@@ -2,13 +2,13 @@ package slimeknights.tconstruct.plugin.jei.drying;
 
 import java.util.Set;
 
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import slimeknights.tconstruct.library.DryingRecipe;
 import slimeknights.tconstruct.library.TinkerRegistry;
 
 public class DryingRecipeChecker {
   public static Set<DryingRecipe> getDryingRecipes() {
-    Set<DryingRecipe> recipes = new ObjectOpenHashSet<>();
+    Set<DryingRecipe> recipes = new ObjectLinkedOpenHashSet<>();
 
     for(DryingRecipe recipe : TinkerRegistry.getAllDryingRecipes()) {
       if(recipe.output != null && recipe.input != null && recipe.input.getInputs() != null && !recipe.input.getInputs().isEmpty()) {

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/smelting/SmeltingRecipeChecker.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/smelting/SmeltingRecipeChecker.java
@@ -4,13 +4,13 @@ import java.util.Set;
 import java.util.List;
 import java.util.ArrayList;
 
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.smeltery.MeltingRecipe;
 
 public class SmeltingRecipeChecker {
   public static Set<MeltingRecipe> getSmeltingRecipesSet() {
-    Set<MeltingRecipe> recipes = new ObjectOpenHashSet<>();
+    Set<MeltingRecipe> recipes = new ObjectLinkedOpenHashSet<>();
 
     for(MeltingRecipe recipe : TinkerRegistry.getAllMeltingRecipies()) {
       if(recipe.output != null && recipe.input != null && recipe.input.getInputs() != null && !recipe.input.getInputs().isEmpty()) {


### PR DESCRIPTION
Linked hash set maintains iteration order (the same as insertion order)