### PR TITLE
Fix deconstruction

### DIFF
--- a/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerToolStation.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerToolStation.java
@@ -455,6 +455,10 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
 
     ItemStack result = ToolBuilder.tryBuildTool(input, toolName, getBuildableTools());
     if(!result.isEmpty()) {
+      if (tile.isDeconstructing()) {
+        result = tile.getDeconstructingStack();
+      }
+
       TinkerCraftingEvent.ToolCraftingEvent.fireEvent(result, player, input);
     }
     return result;

--- a/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerToolStation.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerToolStation.java
@@ -455,7 +455,11 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
 
     ItemStack result = ToolBuilder.tryBuildTool(input, toolName, getBuildableTools());
     if(!result.isEmpty()) {
-      TinkerCraftingEvent.ToolCraftingEvent.fireEvent(result, player, input);
+      if (tile.isDeconstructing()) {
+        result = tile.getDeconstructingStack();
+      } else {
+        TinkerCraftingEvent.ToolCraftingEvent.fireEvent(result, player, input);
+      }
     }
     return result;
   }

--- a/src/main/java/slimeknights/tconstruct/tools/common/tileentity/TileToolStation.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/tileentity/TileToolStation.java
@@ -57,7 +57,7 @@ public class TileToolStation extends TileTable implements IInventoryGui {
       info = ((GuiToolStation) Minecraft.getMinecraft().currentScreen).currentInfo;
     }*/
     
-    if (!this.deconstructingStack.isEmpty()) {
+    if (isDeconstructing()) {
 	  PropertyTableItem.TableItem item = getTableItem(this.deconstructingStack, this.getWorld(), null);
 	  toDisplay.items.add(item);
     } else {


### PR DESCRIPTION
Fixes a bug: when deconstructing, clicking on a greyed-out slot would still trigger the deconstruction (effectively stripping all modifiers and levels). This happened because simply clicking the slots (even if the contents don't change) triggers `onCraftMatrixChanged` for the tool station, which sees parts in the input slots and replaces the tool in the output with a newly crafted one.

The fix is stupid but this is the simplest working thing I could think of.