### PR TITLE
Fix deconstruction dupes

### DIFF
--- a/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerToolStation.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerToolStation.java
@@ -198,7 +198,8 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
         out.inventory.setInventorySlotContents(0, result);
       }
       // if no crafting result and a tool is in the output slot, try deconstruction
-      else if(Config.deconstructTools && !outputStack.isEmpty() && outputStack.getItem() instanceof TinkersItem) {
+      else if(Config.deconstructTools && !outputStack.isEmpty() && outputStack.getItem() instanceof TinkersItem && out.isToolForDeconstruction) {
+        out.isToolForDeconstruction = false;
         if(deconstructTool()) {
           // populate input slots with parts
           NonNullList<ItemStack> parts = getDeconstructedParts(outputStack);
@@ -496,7 +497,11 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
 
   @Override
   public boolean canMergeSlot(ItemStack stack, Slot slot) {
-    return slot != out && super.canMergeSlot(stack, slot);
+    if (slot == out || tile.isDeconstructing() && slot instanceof SlotToolStationIn) {
+      return false;
+    }
+
+    return super.canMergeSlot(stack, slot);
   }
 
   public ToolCore getSelectedTool() {

--- a/src/main/java/slimeknights/tconstruct/tools/common/inventory/SlotToolStationOut.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/inventory/SlotToolStationOut.java
@@ -17,6 +17,7 @@ import javax.annotation.Nonnull;
 public class SlotToolStationOut extends Slot {
 
   public ContainerToolStation parent;
+  public boolean isToolForDeconstruction = false;
 
   public SlotToolStationOut(int index, int xPosition, int yPosition, ContainerToolStation container) {
     super(new InventoryCraftResult(), index, xPosition, yPosition);
@@ -41,6 +42,7 @@ public class SlotToolStationOut extends Slot {
     super.putStack(stack);
     // trigger craft matrix update and sync when a tool is placed in the output slot
     if(isItemValid(stack)) {
+      this.isToolForDeconstruction = true;
       parent.onCraftMatrixChanged(parent.getTile());
       parent.detectAndSendChanges();
     } 


### PR DESCRIPTION
Closes https://github.com/Elite-Modding-Team/TinkersAntique/issues/75 (and a dupe mentioned in the comments)

Additionally disallows shift-clicking stacking parts into preview slots when deconstructing