### PR TITLE
✨ Further improvements to the JEI integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,9 +126,9 @@ dependencies {
     deobfCompile "slimeknights.mantle:Mantle:${config.minecraft_version_short}-${config.mantle_version}"
 
     // compile against the JEI API
-    deobfCompile "mezz.jei:jei_${config.minecraft_version}:${config.jei_version}:api"
+    deobfCompile "mezz.jei:jei_${config.minecraft_version}:${config.jei_version}"
     // at runtime, use the full JEI jar
-    runtime "mezz.jei:jei_${config.minecraft_version}:${config.jei_version}"
+    // runtime "mezz.jei:jei_${config.minecraft_version}:${config.jei_version}"
 
     deobfCompile "curse.maven:hwyla-253449:${config.hwyla_version}"
     deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:${config.probe_version}"

--- a/resources/assets/tconstruct/lang/en_us.lang
+++ b/resources/assets/tconstruct/lang/en_us.lang
@@ -1062,6 +1062,7 @@ gui.jei.material.harvest=Material Harvest Stats
 gui.jei.material.ranged=Material Ranged Stats
 gui.jei.material.projectile=Material Projectile Stats
 gui.jei.material.armor=Material Armor Stats
+gui.jei.material.openbook=Open %s
 
 gui.jei.severing.item_with_beheading=Tool with Beheading
 

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/material/AbstractCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/material/AbstractCategory.java
@@ -16,6 +16,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fluids.FluidStack;
 import org.apache.commons.lang3.text.WordUtils;
+import slimeknights.mantle.util.LocUtils;
 import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.common.ClientProxy;
 import slimeknights.tconstruct.library.Util;
@@ -46,7 +47,7 @@ public abstract class AbstractCategory implements IRecipeCategory<MaterialWrappe
     private static final int BUTTON_HEIGHT = 18;
 
     protected String title, uuid;
-    protected int mouseX, mouseY;
+    protected int mouseX, mouseY, btn_id;
     protected IDrawable background, icon, slot;
     protected MaterialWrapper materialWrapper;
     protected final List<String> relatedParts;
@@ -118,7 +119,6 @@ public abstract class AbstractCategory implements IRecipeCategory<MaterialWrappe
         lineNumber += 3;
         drawTraits(materialWrapper.getTraits(relatedParts), lineNumber);
         drawStats(materialWrapper.getStatInfos(relatedParts), lineNumber);
-        getGuideButton().setHover(mouseX, mouseY);
         getGuideButton().drawButton(minecraft, mouseX, mouseY, 0);
     }
 
@@ -133,7 +133,8 @@ public abstract class AbstractCategory implements IRecipeCategory<MaterialWrappe
             int index = traits.indexOf(iTrait);
             int width = ClientProxy.fontRenderer.getStringWidth(iTrait.getLocalizedName());
             if (isHovered(WIDTH - width, WIDTH, 3 + index, mouseX, mouseY)) {
-                String[] desc = iTrait.getLocalizedDesc().split("\\\\n");
+                // Use the same method to split the description as the guide book.
+                String[] desc = LocUtils.convertNewlines(iTrait.getLocalizedDesc()).split("\n");
                 if (desc.length > 1) {
                     // It seems that some materials have a trait description that is just a single line.
                     String title = TextFormatting.GOLD + desc[0] + TextFormatting.RESET;
@@ -155,7 +156,7 @@ public abstract class AbstractCategory implements IRecipeCategory<MaterialWrappe
 
     protected GuideButton getGuideButton() {
         if (materialWrapper.guideButton == null) {
-            materialWrapper.guideButton = new GuideButton(0, WIDTH - BUTTON_WIDTH, 0, BUTTON_WIDTH, BUTTON_HEIGHT, materialWrapper.material.identifier, new ItemStack(TinkerCommons.book));
+            materialWrapper.guideButton = new GuideButton(btn_id++, WIDTH - BUTTON_WIDTH, 0, BUTTON_WIDTH, BUTTON_HEIGHT, uuid, materialWrapper.material.identifier, materialWrapper.getUseableParts(relatedParts), new ItemStack(TinkerCommons.book));
         }
         return materialWrapper.guideButton;
     }

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/material/AbstractCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/material/AbstractCategory.java
@@ -1,5 +1,6 @@
 package slimeknights.tconstruct.plugin.jei.material;
 
+import com.google.common.collect.Lists;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IGuiItemStackGroup;
@@ -7,6 +8,8 @@ import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.IRecipeCategory;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -17,6 +20,7 @@ import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.common.ClientProxy;
 import slimeknights.tconstruct.library.Util;
 import slimeknights.tconstruct.library.traits.ITrait;
+import slimeknights.tconstruct.shared.TinkerCommons;
 
 import javax.annotation.Nonnull;
 import java.awt.*;
@@ -26,7 +30,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 public abstract class AbstractCategory implements IRecipeCategory<MaterialWrapper> {
-    ResourceLocation icon_location = new ResourceLocation(Util.MODID, "textures/gui/jei/materials.png");
+    protected ResourceLocation icon_location = new ResourceLocation(Util.MODID, "textures/gui/jei/materials.png");
 
     protected static final int LINE_HEIGHT = 10;
     protected static final float LINE_SPACING = 0.5f;
@@ -38,10 +42,14 @@ public abstract class AbstractCategory implements IRecipeCategory<MaterialWrappe
     private static final int REPRES = 1;
     private static final int FLUID = 2;
 
-    String title, uuid;
-    IDrawable background, icon, slot;
-    MaterialWrapper materialWrapper;
-    List<String> relatedParts;
+    private static final int BUTTON_WIDTH = 18;
+    private static final int BUTTON_HEIGHT = 18;
+
+    protected String title, uuid;
+    protected int mouseX, mouseY;
+    protected IDrawable background, icon, slot;
+    protected MaterialWrapper materialWrapper;
+    protected final List<String> relatedParts;
 
     public AbstractCategory(IGuiHelper guiHelper, List<String> parts) {
         this.background = guiHelper.createBlankDrawable(WIDTH, HEIGHT);
@@ -91,7 +99,7 @@ public abstract class AbstractCategory implements IRecipeCategory<MaterialWrappe
             stacks.init(REPRES, true, 0, 0);
             stacks.set(REPRES, item);
         }
-        stacks.init(PARTS, true, WIDTH - 16, 0);
+        stacks.init(PARTS, true, WIDTH - BUTTON_WIDTH * 2, 0);
         stacks.set(PARTS, recipeWrapper.getParts(relatedParts));
     }
 
@@ -99,7 +107,7 @@ public abstract class AbstractCategory implements IRecipeCategory<MaterialWrappe
     public void drawExtras(@Nonnull Minecraft minecraft) {
         ItemStack item = materialWrapper.getMaterial().getRepresentativeItem();
         if (item != null && !item.isEmpty()) {
-            slot.draw(minecraft, WIDTH - 16, 0);
+            slot.draw(minecraft, WIDTH - BUTTON_WIDTH * 2, 0);
         }
         slot.draw(minecraft, 0, 0);
         if (materialWrapper.getMaterial().hasFluid()) {
@@ -110,11 +118,15 @@ public abstract class AbstractCategory implements IRecipeCategory<MaterialWrappe
         lineNumber += 3;
         drawTraits(materialWrapper.getTraits(relatedParts), lineNumber);
         drawStats(materialWrapper.getStatInfos(relatedParts), lineNumber);
+        getGuideButton().setHover(mouseX, mouseY);
+        getGuideButton().drawButton(minecraft, mouseX, mouseY, 0);
     }
 
     @Nonnull
     @Override
     public List<String> getTooltipStrings(int mouseX, int mouseY) {
+        this.mouseX = mouseX;
+        this.mouseY = mouseY;
         List<String> tooltip = new ArrayList<>();
         LinkedList<ITrait> traits = materialWrapper.getTraits(relatedParts);
         traits.forEach(iTrait -> {
@@ -134,7 +146,18 @@ public abstract class AbstractCategory implements IRecipeCategory<MaterialWrappe
             }
         });
         tooltip.addAll(additionalTooltips(materialWrapper.getStatInfos(relatedParts), materialWrapper.getStatDescriptions(relatedParts), mouseX, mouseY));
+
+        if (getGuideButton().mousePressed(mouseX, mouseY)) {
+            tooltip.add(getGuideButton().getTooltip());
+        }
         return tooltip;
+    }
+
+    protected GuideButton getGuideButton() {
+        if (materialWrapper.guideButton == null) {
+            materialWrapper.guideButton = new GuideButton(0, WIDTH - BUTTON_WIDTH, 0, BUTTON_WIDTH, BUTTON_HEIGHT, materialWrapper.material.identifier, new ItemStack(TinkerCommons.book));
+        }
+        return materialWrapper.guideButton;
     }
 
     protected abstract List<String> additionalTooltips(List<String> statInfo, List<String> statDesc, int mouseX, int mouseY);

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/material/GuideButton.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/material/GuideButton.java
@@ -1,0 +1,51 @@
+package slimeknights.tconstruct.plugin.jei.material;
+
+import mezz.jei.gui.elements.DrawableIngredient;
+import mezz.jei.gui.elements.GuiIconButtonSmall;
+import mezz.jei.plugins.vanilla.ingredients.item.ItemStackRenderer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import slimeknights.tconstruct.library.book.TinkerBook;
+
+import javax.annotation.Nonnull;
+
+public class GuideButton extends GuiIconButtonSmall {
+    private final ItemStack book;
+
+    public GuideButton(int buttonId, int x, int y, int widthIn, int heightIn, String material, ItemStack book) {
+        super(buttonId, x, y, widthIn, heightIn, new DrawableIngredient<>(book, new ItemStackRenderer()));
+        this.book = getBookStack(book, material);
+    }
+
+    public String getTooltip() {
+        return I18n.format("gui.jei.material.openbook", this.book.getDisplayName());
+    }
+
+    public void openBook() {
+        TinkerBook.INSTANCE.openGui(book);
+    }
+
+    public boolean mousePressed(int mouseX, int mouseY) {
+        return this.enabled && this.visible && mouseX >= this.x && mouseY >= this.y && mouseX < this.x + this.width && mouseY < this.y + this.height;
+    }
+
+    public void setHover(int mX, int mY) {
+        this.hovered = mousePressed(mX, mY);
+    }
+
+    private ItemStack getBookStack(ItemStack guide, String material) {
+        NBTTagCompound compound = new NBTTagCompound();
+        NBTTagCompound mantle = new NBTTagCompound();
+        NBTTagCompound book = new NBTTagCompound();
+
+        book.setString("page", String.format("materials.%s", material));
+        mantle.setTag("book", book);
+        compound.setTag("mantle", mantle);
+
+        guide.setTagCompound(compound);
+
+        return guide;
+    }
+}

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/material/GuideButton.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/material/GuideButton.java
@@ -3,20 +3,20 @@ package slimeknights.tconstruct.plugin.jei.material;
 import mezz.jei.gui.elements.DrawableIngredient;
 import mezz.jei.gui.elements.GuiIconButtonSmall;
 import mezz.jei.plugins.vanilla.ingredients.item.ItemStackRenderer;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import slimeknights.tconstruct.library.Util;
 import slimeknights.tconstruct.library.book.TinkerBook;
 
-import javax.annotation.Nonnull;
+import java.util.List;
 
 public class GuideButton extends GuiIconButtonSmall {
     private final ItemStack book;
 
-    public GuideButton(int buttonId, int x, int y, int widthIn, int heightIn, String material, ItemStack book) {
+    public GuideButton(int buttonId, int x, int y, int widthIn, int heightIn, String category, String material, List<String> parts, ItemStack book) {
         super(buttonId, x, y, widthIn, heightIn, new DrawableIngredient<>(book, new ItemStackRenderer()));
-        this.book = getBookStack(book, material);
+        this.book = getBookStack(book, category, material, parts);
     }
 
     public String getTooltip() {
@@ -31,16 +31,48 @@ public class GuideButton extends GuiIconButtonSmall {
         return this.enabled && this.visible && mouseX >= this.x && mouseY >= this.y && mouseX < this.x + this.width && mouseY < this.y + this.height;
     }
 
-    public void setHover(int mX, int mY) {
-        this.hovered = mousePressed(mX, mY);
-    }
-
-    private ItemStack getBookStack(ItemStack guide, String material) {
+    private ItemStack getBookStack(ItemStack guide, String category, String material, List<String> parts) {
         NBTTagCompound compound = new NBTTagCompound();
         NBTTagCompound mantle = new NBTTagCompound();
         NBTTagCompound book = new NBTTagCompound();
 
-        book.setString("page", String.format("materials.%s", material));
+        String type = null;
+        /*
+         * The problem with linking the other types to the correct page of the book is that the
+         * pages with bow materials have a weird naming convention, that makes it impossible to
+         * link to the proper page. Example: "bowmaterials.bow_cactus_bone_obsidian".
+         * That is why I just link to the general material overview page for now.
+         *
+         * Maybe this can be improved in the future, when the guide book is reworked.
+         */
+        switch (category) {
+            case Util.MODID + ":projectile_stats":
+                if (parts.size() == 1) {
+                    switch (parts.get(0)) {
+                        case "fletching":
+                            type = "bowmaterials.page3";
+                            break;
+                        case "shaft":
+                            type = "bowmaterials.page2";
+                            break;
+                    }
+                }
+                break;
+            case Util.MODID + ":ranged_stats":
+                if (parts.size() == 1) {
+                    switch (parts.get(0)) {
+                        case "bow":
+                            type = "bowmaterials.page0";
+                            break;
+                        case "bowstring":
+                            type = "bowmaterials.page1";
+                            break;
+                    }
+                }
+                break;
+        }
+
+        book.setString("page", String.format("%s", type == null ? "materials." + material : type));
         mantle.setTag("book", book);
         compound.setTag("mantle", mantle);
 

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/material/MaterialWrapper.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/material/MaterialWrapper.java
@@ -78,6 +78,19 @@ public class MaterialWrapper implements IRecipeWrapper {
         return partList;
     }
 
+    public List<String> getUseableParts(List<String> parts) {
+        List<String> useableParts = new ArrayList<>();
+        for (String partType : parts) {
+            for (IToolPart part : TinkerRegistry.getToolParts()) {
+                if (part.hasUseForStat(partType) && part.canUseMaterial(material)) {
+                    useableParts.add(partType);
+                    break; // No need to check other parts if we found a match
+                }
+            }
+        }
+        return useableParts;
+    }
+
     public LinkedList<ITrait> getTraits(List<String> parts) {
         LinkedList<ITrait> traitList = new LinkedList<>();
         for (String part : parts) {
@@ -123,6 +136,6 @@ public class MaterialWrapper implements IRecipeWrapper {
             guideButton.openBook();
             return true;
         }
-		return false;
-	}
+        return false;
+    }
 }

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/material/MaterialWrapper.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/material/MaterialWrapper.java
@@ -3,6 +3,7 @@ package slimeknights.tconstruct.plugin.jei.material;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
+import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import slimeknights.tconstruct.library.TinkerRegistry;
@@ -12,12 +13,15 @@ import slimeknights.tconstruct.library.materials.MaterialTypes;
 import slimeknights.tconstruct.library.tools.IToolPart;
 import slimeknights.tconstruct.library.traits.ITrait;
 
+import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class MaterialWrapper implements IRecipeWrapper {
     final Material material;
+
+    protected GuideButton guideButton;
 
     public MaterialWrapper(Material material) {
         this.material = material;
@@ -111,4 +115,14 @@ public class MaterialWrapper implements IRecipeWrapper {
         internal_parts.forEach(part -> stats.add(material.getStats(part)));
         return stats.stream().filter(Objects::nonNull).collect(Collectors.toList());
     }
+
+    @Override
+    public boolean handleClick(@Nonnull Minecraft minecraft, int mouseX, int mouseY, int mouseButton) {
+        // I have no idea why JEI want's to do all the user interaction in the wrapper instead of the category, but here we are.
+        if (guideButton != null && guideButton.mousePressed(minecraft, mouseX, mouseY)) {
+            guideButton.openBook();
+            return true;
+        }
+		return false;
+	}
 }

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/material/RangedCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/material/RangedCategory.java
@@ -31,7 +31,7 @@ public class RangedCategory extends AbstractCategory {
 
     @Override
     protected void drawStats(LinkedList<String> statInfo, float lineNumber) {
-        String heading = getHeading(statInfo.size() == 3 ? "stat.bow.name" : "stat.bowstring.name");
+        String heading = getHeading(statInfo.size() >= 2 ? "stat.bow.name" : "stat.bowstring.name");
         drawComponent(heading, 0, lineNumber++, materialWrapper.material.materialTextColor, true);
         lineNumber += HEADING_SPACING;
         for (String s : statInfo) {


### PR DESCRIPTION
## 🔎 What does this PR do?
- I switched to the default way tinkers formats their trait tooltips to fix issues that appeared when displaying custom materials traits added by mods like contenttweaker
- added a button to the JEI page that opens the "Materials and You" book at the designated location, which makes it easier to look up a specific material. The book isn't required to be in the inventory for it to work.
- I _tried_ to make it work with the bow and projectile pages as well, but the book has a horrible way to "name" it's pages and I'm not going to touch the guide (_yet_) as it will probably end up in a complete rewrite...
- so for now it _tries_ to open the pages with the material selection for bolts, bow, bowstring and fletching, otherwise it defaults to the general material page
- I fixed a few small bugs and typos I found in my JEI code
- I also had to tweak the gradle file to access JEI stuff that isn't in the API like the button stuff, otherwise I would have to write all of that from scratch, but this _shouldn't_ impact further development, so instead of only the API, we also depend on the rest of it as well

## 🖼️ Images - because who want's to read?
This is the new button I added:
<img width="967" height="656" alt="image" src="https://github.com/user-attachments/assets/9bebb7c0-988e-46db-a807-0db95b1d405f" />

This should no longer happen with the new approach on formatting the tooltip:
<img width="520" height="322" alt="image" src="https://github.com/user-attachments/assets/dd7a7d79-49b6-4d94-8dee-a6c408dfdd85" />
