### PR TITLE
Don't generate Village Loot or Structures when modules are disabled

### DIFF
--- a/src/main/java/slimeknights/tconstruct/world/TinkerWorld.java
+++ b/src/main/java/slimeknights/tconstruct/world/TinkerWorld.java
@@ -119,8 +119,10 @@ public class TinkerWorld extends TinkerPulse {
   // PRE-INITIALIZATION
   @Subscribe
   public void preInit(FMLPreInitializationEvent event) {
-    if(Config.genVillageStructures) {
+    if(Config.genVillageStructures && isToolsLoaded()) {
       VillagerRegistry.instance().registerVillageCreationHandler(new VillageToolWorkshopHandler());
+    }
+    if(Config.genVillageStructures && isSmelteryLoaded()) {
       VillagerRegistry.instance().registerVillageCreationHandler(new VillageSmelteryHandler());
     }
     proxy.preInit();
@@ -129,7 +131,9 @@ public class TinkerWorld extends TinkerPulse {
   // INITIALIZATION
   @Subscribe
   public void init(FMLInitializationEvent event) {
-    MinecraftForge.EVENT_BUS.register(new VillageLoot());
+    if(Config.genVillageStructures && isToolsLoaded()) {
+      MinecraftForge.EVENT_BUS.register(new VillageLoot());
+    }
     proxy.init();
   }
 


### PR DESCRIPTION
Disable Village Loot Tables population when village structure generation is disabled or the Tools module is disabled. Same thing for the two structures that are now disabled if the Tools or Smeltery modules are disabled, respectively.

Should fix and close https://github.com/Elite-Modding-Team/TinkersAntique/issues/163