### PR TITLE
Remove vanilla limits on Crafting Station's side inventory

### DIFF
--- a/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerCraftingStation.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerCraftingStation.java
@@ -5,6 +5,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.inventory.ClickType;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryCraftResult;
 import net.minecraft.inventory.InventoryCrafting;
@@ -169,6 +170,18 @@ public class ContainerCraftingStation extends ContainerTinkerStation<TileCraftin
   }
 
   @Override
+  public ItemStack slotClick(int slotId, int dragType, ClickType type, EntityPlayer player) {
+    if(type == ClickType.PICKUP && slotId >= 0) {
+      ItemStack stack = handleSideInventoryPickup(slotId, dragType, player);
+      if(stack != null) {
+        return stack;
+      }
+    }
+
+    return super.slotClick(slotId, dragType, type, player);
+  }
+
+  @Override
   protected void slotChangedCraftingGrid(World world, EntityPlayer player, InventoryCrafting inv, InventoryCraftResult result) {
     ItemStack itemstack = ItemStack.EMPTY;
 
@@ -235,8 +248,101 @@ public class ContainerCraftingStation extends ContainerTinkerStation<TileCraftin
   }
 
   @Override
+  protected boolean mergeItemStackRefill(ItemStack stack, int startIndex, int endIndex, boolean useEndIndex) {
+    if(stack.getCount() <= 0) {
+      return false;
+    }
+
+    boolean merged = false;
+    int index = useEndIndex ? endIndex - 1 : startIndex;
+
+    if(stack.isStackable()) {
+      while(stack.getCount() > 0 && (!useEndIndex && index < endIndex || useEndIndex && index >= startIndex)) {
+        Slot slot = this.inventorySlots.get(index);
+        ItemStack slotStack = slot.getStack();
+
+        if(!slotStack.isEmpty()
+           && slotStack.getItem() == stack.getItem()
+           && (!stack.getHasSubtypes() || stack.getMetadata() == slotStack.getMetadata())
+           && ItemStack.areItemStackTagsEqual(stack, slotStack)
+           && this.canMergeSlot(stack, slot)) {
+          int limit = getMergeItemStackLimit(stack, slot);
+          int mergedCount = slotStack.getCount() + stack.getCount();
+
+          if(mergedCount <= limit) {
+            stack.setCount(0);
+            slotStack.setCount(mergedCount);
+            slot.onSlotChanged();
+            merged = true;
+          }
+          else if(slotStack.getCount() < limit) {
+            stack.shrink(limit - slotStack.getCount());
+            slotStack.setCount(limit);
+            slot.onSlotChanged();
+            merged = true;
+          }
+        }
+
+        if(useEndIndex) {
+          --index;
+        }
+        else {
+          ++index;
+        }
+      }
+    }
+
+    return merged;
+  }
+
+  @Override
   public boolean canMergeSlot(ItemStack p_94530_1_, Slot p_94530_2_) {
     return p_94530_2_.inventory != this.craftResult && super.canMergeSlot(p_94530_1_, p_94530_2_);
+  }
+
+  private ItemStack handleSideInventoryPickup(int slotId, int dragType, EntityPlayer player) {
+    Slot slot = this.inventorySlots.get(slotId);
+    if(slot == null || !isSideInventorySlot(slot)) {
+      return null;
+    }
+
+    ItemStack slotStack = slot.getStack();
+    ItemStack heldStack = player.inventory.getItemStack();
+    if(slotStack.isEmpty() || heldStack.isEmpty() || !slot.canTakeStack(player) || !slot.isItemValid(heldStack)) {
+      return null;
+    }
+
+    if(slotStack.getItem() != heldStack.getItem()
+       || slotStack.getMetadata() != heldStack.getMetadata()
+       || !ItemStack.areItemStackTagsEqual(slotStack, heldStack)) {
+      return null;
+    }
+
+    int remainingSpace = slot.getItemStackLimit(heldStack) - slotStack.getCount();
+    if(remainingSpace > 0) {
+      int moved = dragType == 0 ? heldStack.getCount() : 1;
+      if(moved > remainingSpace) {
+        moved = remainingSpace;
+      }
+
+      heldStack.shrink(moved);
+      slotStack.grow(moved);
+    }
+
+    slot.onSlotChanged();
+    return slotStack.copy();
+  }
+
+  private int getMergeItemStackLimit(ItemStack stack, Slot slot) {
+    if(isSideInventorySlot(slot)) {
+      return slot.getItemStackLimit(stack);
+    }
+
+    return Math.min(stack.getMaxStackSize(), slot.getItemStackLimit(stack));
+  }
+
+  private boolean isSideInventorySlot(Slot slot) {
+    return slot.slotNumber >= 0 && this.getSlotContainer(slot.slotNumber) instanceof ContainerSideInventory;
   }
 
   protected TileEntity detectInventory() {

--- a/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerSideInventory.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerSideInventory.java
@@ -1,10 +1,15 @@
 package slimeknights.tconstruct.tools.common.inventory;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.SlotItemHandler;
+
+import javax.annotation.Nonnull;
 
 import slimeknights.mantle.inventory.BaseContainer;
 
@@ -41,7 +46,79 @@ public class ContainerSideInventory<T extends TileEntity> extends BaseContainer<
   }
 
   protected Slot createSlot(IItemHandler itemHandler, int index, int x, int y) {
+    if(itemHandler instanceof IItemHandlerModifiable) {
+      return new ExternalSlotItemHandler(itemHandler, (IItemHandlerModifiable) itemHandler, index, x, y);
+    }
+
     return new SlotItemHandler(itemHandler, index, x, y);
+  }
+
+  private static class ExternalSlotItemHandler extends SlotItemHandler {
+
+    private final IItemHandler itemHandler;
+    private final IItemHandlerModifiable modifiableItemHandler;
+    private final int index;
+
+    private ExternalSlotItemHandler(IItemHandler itemHandler, IItemHandlerModifiable modifiableItemHandler, int index, int xPosition, int yPosition) {
+      super(itemHandler, index, xPosition, yPosition);
+      this.itemHandler = itemHandler;
+      this.modifiableItemHandler = modifiableItemHandler;
+      this.index = index;
+    }
+
+    @Override
+    public boolean isItemValid(@Nonnull ItemStack stack) {
+      return !stack.isEmpty() && itemHandler.isItemValid(index, stack);
+    }
+
+    @Nonnull
+    @Override
+    public ItemStack getStack() {
+      return itemHandler.getStackInSlot(index);
+    }
+
+    @Override
+    public void putStack(@Nonnull ItemStack stack) {
+      modifiableItemHandler.setStackInSlot(index, stack);
+      this.onSlotChanged();
+    }
+
+    @Override
+    public void onSlotChange(@Nonnull ItemStack oldStack, @Nonnull ItemStack newStack) {
+    }
+
+    @Override
+    public int getSlotStackLimit() {
+      return itemHandler.getSlotLimit(index);
+    }
+
+    @Override
+    public int getItemStackLimit(@Nonnull ItemStack stack) {
+      return this.getSlotStackLimit();
+    }
+
+    @Override
+    public boolean canTakeStack(EntityPlayer playerIn) {
+      return !itemHandler.extractItem(index, 1, true).isEmpty();
+    }
+
+    @Nonnull
+    @Override
+    public ItemStack decrStackSize(int amount) {
+      ItemStack currentStack = this.getStack();
+      if(currentStack.isEmpty() || amount <= 0) {
+        return ItemStack.EMPTY;
+      }
+
+      ItemStack removedStack = currentStack.splitStack(Math.min(amount, currentStack.getCount()));
+      modifiableItemHandler.setStackInSlot(index, currentStack.isEmpty() ? ItemStack.EMPTY : currentStack);
+      return removedStack;
+    }
+
+    @Override
+    public boolean isSameInventory(Slot other) {
+      return other instanceof ExternalSlotItemHandler && ((ExternalSlotItemHandler) other).itemHandler == this.itemHandler;
+    }
   }
 
   public int getSlotCount() {


### PR DESCRIPTION
Currently, any "put back" and "merge" operation on the side inventory of the Crafting Station is limited to 64, because it uses a basic Forge slot, which limits these to the item's stack size. This is kinda annoying for attached container with higher slot size, like Storage Danks, as you can take an oversized stack (like 1024), but only put back 64 in each slot. The workaround I used to this point was to attach an Item Collector to the storage and throw the items on the ground, but it's far from ideal.

This PR adds a Slot that properly uses the underlying container's slot size :
- Putting back into an empty slot works
- Merging with a non-empty slot works
- Shift-click from the table to put the item back into the container works
- The attached container's limit is respected (e.g. 64 for a chest)

**Note:** for some reason, the gradle was erroring at :deobfCompileDeobfDepTask1 (java.lang.IllegalArgumentException in org.objectweb.asm.ClassReader.<init>, both via command line and IntelliJ). I had to move the gradle to ForgeDevEnv locally, but I haven't pushed any of that in this PR.