### PR TITLE
Fix build failing in :deobfCompileDeobfDepTask1

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -6,7 +6,7 @@ mappings=snapshot_20170801
 
 mantle_version=1.3.3.55
 
-jei_version=4.16.+
+jei_version=4.16.5.1029
 hwyla_version=2568751
 probe_version=1.12-1.4.28-17
 redstoneflux_version=1.12-2.0.0.+


### PR DESCRIPTION
Fix build failing due to JEI having moved from Java 8 to Java 21 in version 4.16.5.1030 (August 28th, https://github.com/mezz/JustEnoughItems/commit/f98331af6b1f7d59da01beecacd681c16dd548b9), which the old(-ish) gradle of Tinkers cannot handle. A proper fix would be to move to a proper ForgeDevEnv, but `snapshot_20170801` makes it somewhat annoying, due to joined.exc issues (1). This is a ~permanent~ temporary fix until then.

(1) The joined.exc and joined.srg are not handled for snapshot, so you need to add a gradle task to download them and put them in cache.